### PR TITLE
Fix parsing/encoding IPv6 with an empty group

### DIFF
--- a/ip.js
+++ b/ip.js
@@ -24,7 +24,10 @@ ipemotes.processRemainder = (number) => {
 
 //Converts a decimal number to an emoji or emojis (depending on size of number and size of eLength)
 ipemotes.numToEmoji = (number) => {
-    if (number > eLength) {
+    if (isNaN(number)) {
+        return '';
+    }
+    else if (number > eLength) {
         let string = '';
         const pow = ipemotes.discoverPow(number);
         const powered = Math.pow(eLength, pow);
@@ -99,6 +102,10 @@ ipemotes.convertEmojiToIpv6 = (address) => {
     let string = '';
     for (let index = 0; index < address.length; index++) {
         let element = address[index];
+        if (element.length === 0) {
+            string += ':';
+            continue;
+        }
         element = ipemotes.parseEmoji(ipemotes.emotesToArray(element));
         let hexy = element.toString(16);
         while(hexy.length < 4) hexy = '0'+hexy;


### PR DESCRIPTION
## Overview

This PR fixes parsing and encoding IPv6 addresses that contain an empty group. An example IPv6 address (where an empty group is synonymous with a zero value, i.e., `0000`):

`2607:f8b0:4000:813::200e`

Before this fix, the encoded (and resulting parsed) emoji address returned empty groups as undefined. 

|**Encoded**|**Parsed**|
|:-----|:-----|
|`🌊☎:🤺💤:🍛⏰:☕⚽:undefined:⭐♻`|`2607:f8b0:4000:0813:-10101010101010000:200e`|

After fixing, the encoding and parsing correctly show an empty group.

|**Encoded**|**Parsed**|
|:-----|:-----|
|`🌊☎:🤺💤:🍛⏰:☕⚽::⭐♻`|`2607:f8b0:4000:0813::200e`|

One note: the re-parsed emoji to IPv6 isn't identical to the original, as IPv6 groups are left-padded with `0`, making the fourth group `0813` vs the original `813`. This doesn't change the _value_ of the IPv6 address, and there's no way to avoid this discrepancy as the input groups may or may not be left padded.

## Detailed Changes

* Added check for `isNaN` in `numToEmoji()` input parameter
* Added early continue in `convertEmojiToIpv6()` when an emoji address group length is zero